### PR TITLE
update ruff to lint for python 3.12

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -114,7 +114,7 @@ line-length = 120
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Assume Python 3.11.
-target-version = "py311"
+target-version = "py312"
 
 [mccabe]
 # Unlike Flake8, default to a complexity level of 10.


### PR DESCRIPTION
Updated Ruff rules to assume Python 3.12