### PR TITLE
changed from trigger on tags to release

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set version from tag
+        run: |
+          RELEASE_TAG=${{ github.ref_name }}
+          echo "$RELEASE_TAG"
+          sed -i -e 's/^version = "*.*.*"/version = "'"$RELEASE_TAG"'"/g' pyproject.toml
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -47,9 +47,9 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          tags: eu.gcr.io/toolsense/python-project-template:latest
-          push: true
+      # - name: Build and push
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     tags: eu.gcr.io/toolsense/python-project-template:latest
+      #     push: true

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,9 +1,8 @@
 name: deploy_prod
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [released]
 
 jobs:
   test_and_lint:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -3,6 +3,7 @@ name: Deploy Production
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   test_and_lint:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,4 +1,4 @@
-name: deploy_prod
+name: Deploy Production
 
 on:
   release:

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -1,4 +1,4 @@
-name: deploy_stage
+name: Deploy Development
 
 on:
   push:


### PR DESCRIPTION
Using a proper release as a trigger instead of creation of a tag. Tags can be used for other things and does not necessarily mean a new release.

Adding workflow_dispatch to production for testing setting of version.