### PR TITLE
remove workflow dispatch on prod

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -3,7 +3,6 @@ name: Deploy Production
 on:
   release:
     types: [released]
-  workflow_dispatch:
 
 jobs:
   test_and_lint:
@@ -48,9 +47,9 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
-      # - name: Build and push
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: .
-      #     tags: eu.gcr.io/toolsense/python-project-template:latest
-      #     push: true
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          tags: eu.gcr.io/toolsense/python-project-template:latest
+          push: true

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   test_and_lint:

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -7,6 +7,7 @@ on:
     types: [ opened, synchronize, reopened ]
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   test_and_lint:


### PR DESCRIPTION
The deployment of the production environment should only be done with releases, so removed workflow_dispatch from production deployment flow.

It doesn't hurt to use workflow_dispatch for the linting stage. Enabling it also for the staging deployment would even bring some advantages such as being able to deploy branches to staging for testing. It would also make it easy to switch back in case it didn't work.