### PR TITLE
Migrate-to-uv

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Rye
-        uses: eifinger/setup-rye@v4
+      - name: Setup uv
+        uses: eifinger/setup-uv@v1
 
-      - name: Sync Rye
+      - name: Sync Python and dependencies
         run: make sync
 
       - name: Check formatting
@@ -50,14 +50,14 @@ jobs:
           echo "$RELEASE_TAG"
           sed -i -e 's/^version = "*.*.*"/version = "'"$RELEASE_TAG"'"/g' pyproject.toml
 
-      - name: Set up Rye
-        uses: eifinger/setup-rye@v4
+      - name: Setup uv
+        uses: eifinger/setup-uv@v1
 
-      - name: Sync Rye (Create virtual env and install dependencies)
+      - name: Sync Python and dependencies
         run: make sync
 
       - name: Build package
-        run: rye build
+        run: uv build
 
       - name: Upload packages to Release
         if: github.event_name == 'release'
@@ -72,4 +72,4 @@ jobs:
           REPO_URL: "https://europe-west1-python.pkg.dev/toolsense/toolsense-py-utils/"
           USERNAME: "_json_key_base64"
         run: |
-          rye publish -r ${{ env.REPO_NAME }} --repository-url ${{ env.REPO_URL }} --username ${{ env.USERNAME }} --token ${{ env.PASSWORD }} -y
+          uvx twine upload --repository ${{ env.REPO_NAME }} --repository-url ${{ env.REPO_URL }} --username ${{ env.USERNAME }} --password ${{ env.PASSWORD }} dist/*

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup uv
-        uses: eifinger/setup-uv@v1
+        uses: astral-sh/setup-uv@v2
 
       - name: Sync Python and dependencies
         run: make sync
@@ -51,7 +51,7 @@ jobs:
           sed -i -e 's/^version = "*.*.*"/version = "'"$RELEASE_TAG"'"/g' pyproject.toml
 
       - name: Setup uv
-        uses: eifinger/setup-uv@v1
+        uses: astral-sh/setup-uv@v2
 
       - name: Sync Python and dependencies
         run: make sync

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Rye
-        uses: eifinger/setup-rye@v4
+      - name: Setup uv
+        uses: eifinger/setup-uv@v1
 
-      - name: Sync Rye
+      - name: Sync Python and dependencies
         run: make sync
 
       - name: Check formatting

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup uv
-        uses: eifinger/setup-uv@v1
+        uses: astral-sh/setup-uv@v2
 
       - name: Sync Python and dependencies
         run: make sync

--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ target/
 profile_default/
 ipython_config.py
 
-# pyenv (Rye)
+# pyenv (uv)
 .python-version
 
 # pipenv

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all init sync prod lint format check check_lint check_format check_types coverage test run run_docker docker_up docker_down clean
 
 SHELL:=/bin/bash
-RUN=rye run
+RUN=uv run
 PYTHON=${RUN} python
 
 all:
@@ -39,31 +39,31 @@ all:
 	@echo "    Remove python artifacts and virtualenv"
 
 init:
-	rye init --py 3.12
+	uv init --python 3.12
 
 sync:
-	rye sync
+	uv sync
 
 prod:
-	rye sync --no-dev
+	uv sync --no-dev
 
 lint: format
-	rye lint --fix
+	${RUN} ruff check --fix
 
 format:
-	rye fmt
-
-check_lint:
-	rye lint
+	${RUN} ruff format src
 
 check_format:
-	rye format --check
+	${RUN} ruff format --check src
+
+check_lint:
+	${RUN} ruff check
 
 check_types:
-	${RUN} mypy -p toolsense.flespi
+	${RUN} mypy -p toolsense.python_project_template
 	${RUN} mypy src/tests
 
-check: sync check_format check_lint check_types
+check: sync check_format check_lint check_types test
 
 coverage: sync docker_up
 	${RUN} coverage run -m pytest

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Enjoy the development of your new project :beach_umbrella:
 * Dockerfile & docker-compose
 
 ## Python Project management
-This project template is using rye as a python project manager. There are several advantages to this as rye will act as package manager and also manage virtual environment completely decoupled from your local setup. This means, as long as you have rye installed, it will completely manage the project locally.
+This project template is using uv as a python project manager. There are several advantages to this as uv will act as package manager and also manage virtual environment completely decoupled from your local setup. This means, as long as you have uv installed, it will completely manage the project locally.
 
-To install rye on your computer, follow the [guide](https://rye-up.com/guide/).
+To install uv on your computer, follow the [guide](https://docs.astral.sh/uv/).
 
 1. Create a new Repository with this as repo as template
 2. Clone the repo
 3. Run `make init`
-4. run `rye sync`
+4. run `uv sync`
 
-The `make init`-command sets up the folders for sources and creates a pyproject.toml, internally it uses `rye init --py 3.12` to add Python 3.12.x as required. The command `rye sync` creates a virtual environment in a .venv locally and install all the packages as specified in the pyprojects.toml.
+The `make init`-command sets up the folders for sources and creates a pyproject.toml, internally it uses `uv init --python 3.12` to add Python 3.12.x as required. The command `uv sync` creates a virtual environment in a .venv locally and install all the packages as specified in the pyprojects.toml.
 
 ### Dependencies
-To add dependencies use `rye add` and `rye sync` after wards. To add development dependencies use the command `rye add -- dev <package name>`. When you run `rye sync` it automatically downloads and install all packages, including development requirements. To skip installation of development dependencies, use `rye sync --no-dev`.
+To add dependencies use `uv add` and `uv sync` after wards. To add development dependencies use the command `uv add --dev <package name>`. When you run `uv sync` it automatically downloads and install all packages, including development requirements. To skip installation of development dependencies, use `uv sync --no-dev`.
 
 There are two ways to import local modules, either absolute or relative:
 - Absolute import works for a built package as well as when running the script locally. It might raise some Pylance errors during use.
@@ -103,5 +103,4 @@ For example `make check` will do:
 GitHub Actions use the same (`make check`) command to check pull requests.
 
 ## ToDo
-
 * Pre-commit hook

--- a/pyproject.toml.sample
+++ b/pyproject.toml.sample
@@ -5,24 +5,31 @@ description = "Add your description here"
 authors = [
     { name = "Robert Nyström", email = "robert.nystrom@toolsense.io" }
 ]
-dependencies = []
-readme = "README.md"
-requires-python = ">= 3.12"
 
-[project.scripts]
-flespi = "toolsense.flespi.cli.main:main"
+requires-python = ">=3.12"
+
+dependencies = [
+    "result==0.17.0",
+    "fastapi==0.114.0",
+    "uvicorn==0.30.6",
+    "pydantic==2.9.1",
+    "google-cloud-pubsub==2.23.0",
+    "pydantic-settings==2.4.0",
+    "valkey>=6.0.0",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "coverage>=7.6.1",
+    "mypy>=1.11.2",
+    "pytest>=8.3.2",
+    "pytest-mock>=3.14.0",
+    "ruff>=0.6.2",
+]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.rye]
-managed = true
-dev-dependencies = [
-    "pytest>=8.0.1",
-    "mypy>=1.8.0",
-    "coverage>=7.4.1",
-]
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -35,7 +42,7 @@ branch = true
 source = ["src/toolsense"]
 data_file = "coverage/.coverage"
 relative_files = true
-omit = ["*/tests/*", "*/cli/*"]
+omit = ["*/tests/*"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Migrate the project from using 'rye' to 'uv' for managing Python environment and dependencies, including updates to the Makefile and CI workflows.

Build:
- Replace 'rye' with 'uv' in the Makefile for running Python commands and managing dependencies.

CI:
- Update CI workflows to replace 'rye' with 'uv' for setting up the environment, syncing dependencies, building packages, and publishing artifacts.

<!-- Generated by sourcery-ai[bot]: end summary -->